### PR TITLE
Adds CSV download feature

### DIFF
--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -2,21 +2,7 @@ from asnake.aspace import ASpace
 from request_broker import settings
 
 
-class Routine:
-    """
-    Base routine class which is inherited by all other routines.
-
-    Provides default clients for ArchivesSpace.
-    """
-
-    def __init__(self):
-        self.aspace = ASpace(baseurl=settings.ARCHIVESSPACE["baseurl"],
-                             username=settings.ARCHIVESSPACE["username"],
-                             password=settings.ARCHIVESSPACE["password"],
-                             repository=settings.ARCHIVESSPACE["repo_id"])
-
-
-class ProcessRequest(Routine):
+class ProcessRequest(object):
     # TODO: main section where processing happens
     # Push requests to submitted or unsubmitted
     # If open and delivery formats, mark as submittable
@@ -38,7 +24,11 @@ class ProcessRequest(Routine):
         Returns:
             obj (dict): A JSON representation of an ArchivesSpace Archival Object.
         """
-        obj = self.aspace.client.get(item)
+        aspace = ASpace(baseurl=settings.ARCHIVESSPACE["baseurl"],
+                        username=settings.ARCHIVESSPACE["username"],
+                        password=settings.ARCHIVESSPACE["password"],
+                        repository=settings.ARCHIVESSPACE["repo_id"])
+        obj = aspace.client.get(item)
         if obj.status_code == 200:
             return obj.json()
         else:
@@ -248,35 +238,29 @@ class ProcessRequest(Routine):
             object_list (list): A list of AS archival object URIs.
 
         Returns:
-            A streaming CSV file
+            A list of dicts containing data to be downloaded.
         """
+        processed = []
         for item in object_list:
             try:
-                self.get_data(item)
-                print('after get_data')
+                processed.append(self.get_data(item))
             except Exception as e:
-                print(e)
-            return 'test'
+                print("Error processing item {}: {}".format(item, e))
+        return processed
 
 
-class DeliverEmail(Routine):
+class DeliverEmail(object):
     """Sends an email with request data to an email address or list of addresses.
     """
     pass
 
 
-class DeliverReadingRoomRequest(Routine):
+class DeliverReadingRoomRequest(object):
     """Sends submitted data to Aeon for transaction creation in Aeon.
     """
     pass
 
 
-class DeliverDuplicationRequest(Routine):
+class DeliverDuplicationRequest(object):
     """Sends submitted data for duplication request creation in Aeon.
     """
-
-
-class DeliverCSV(Routine):
-    """Create a streaming csv file based on original request.
-    """
-    pass

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -231,23 +231,6 @@ class ProcessRequest(object):
                 print(e)
             return 'test'
 
-    def process_csv_request(self, object_list):
-        """Processes requests for a CSV download.
-
-        Args:
-            object_list (list): A list of AS archival object URIs.
-
-        Returns:
-            A list of dicts containing data to be downloaded.
-        """
-        processed = []
-        for item in object_list:
-            try:
-                processed.append(self.get_data(item))
-            except Exception as e:
-                print("Error processing item {}: {}".format(item, e))
-        return processed
-
 
 class DeliverEmail(object):
     """Sends an email with request data to an email address or list of addresses.

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -205,8 +205,7 @@ class ProcessRequest(object):
         """
         for item in object_list:
             try:
-                data = self.get_data(item)
-                print(data)
+                self.get_data(item)
             except Exception as e:
                 print(e)
             return 'test'

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -1,3 +1,7 @@
+import csv
+from datetime import datetime
+
+from django.http import StreamingHttpResponse
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -13,3 +17,41 @@ class ProcessRequestView(APIView):
         object_list = request.data.get('items')
         process_list = ProcessRequest().process_readingroom_request(object_list)
         return Response(process_list, status=200)
+
+
+class Echo:
+    """An object that implements just the write method of the file-like
+    interface, returning the object instead of buffering. Used to stream
+    downloads.
+    """
+
+    def write(self, value):
+        return value
+
+
+class DownloadCSVView(APIView):
+    """Downloads a CSV file."""
+
+    def iter_items(self, items, pseudo_buffer):
+        """Returns an iterable containing the spreadsheet rows."""
+        fieldnames = ["creator", "collection_name", "aggregation", "dates",
+                      "resource_id", "container", "title", "restrictions", "ref"]
+        writer = csv.DictWriter(pseudo_buffer, fieldnames=fieldnames, extrasaction="ignore")
+        yield pseudo_buffer.write(fieldnames)
+        for row in items:
+            yield writer.writerow(row)
+
+    def post(self, request):
+        """Streams a large CSV file."""
+        try:
+            submitted = request.data.get("items")
+            rows = ProcessRequest().process_csv_request(submitted)
+            response = StreamingHttpResponse(
+                streaming_content=(self.iter_items(rows, Echo())),
+                content_type="text/csv",
+            )
+            filename = "dimes-{}.csv".format(datetime.now().isoformat())
+            response["Content-Disposition"] = "attachment; filename={}".format(filename)
+            return response
+        except Exception as e:
+            return Response({"detail": "Unable to download data: {}".format(e)}, status=500)

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -37,7 +37,7 @@ class DownloadCSVView(APIView):
         fieldnames = ["creator", "collection_name", "aggregation", "dates",
                       "resource_id", "container", "title", "restrictions", "ref"]
         writer = csv.DictWriter(pseudo_buffer, fieldnames=fieldnames, extrasaction="ignore")
-        yield pseudo_buffer.write(fieldnames)
+        yield writer.writerow(dict((fn, fn) for fn in writer.fieldnames))
         for row in items:
             yield writer.writerow(row)
 
@@ -55,4 +55,4 @@ class DownloadCSVView(APIView):
             response["Content-Disposition"] = "attachment; filename={}".format(filename)
             return response
         except Exception as e:
-            return Response({"detail": "Unable to download data: {}".format(e)}, status=500)
+            return Response({"detail": str(e)}, status=500)

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -45,9 +45,10 @@ class DownloadCSVView(APIView):
         """Streams a large CSV file."""
         try:
             submitted = request.data.get("items")
-            rows = ProcessRequest().process_csv_request(submitted)
+            processor = ProcessRequest()
+            fetched = [processor.get_data(item) for item in submitted]
             response = StreamingHttpResponse(
-                streaming_content=(self.iter_items(rows, Echo())),
+                streaming_content=(self.iter_items(fetched, Echo())),
                 content_type="text/csv",
             )
             filename = "dimes-{}.csv".format(datetime.now().isoformat())

--- a/request_broker/urls.py
+++ b/request_broker/urls.py
@@ -15,13 +15,14 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
-from process_request.views import ProcessRequestView
+from process_request.views import DownloadCSVView, ProcessRequestView
 from rest_framework import routers
 
 router = routers.DefaultRouter()
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', include(router.urls)),
-    path('api/process-request/', ProcessRequestView.as_view(), name='process-request')
+    path("admin/", admin.site.urls),
+    path("", include(router.urls)),
+    path("api/process-request/", ProcessRequestView.as_view(), name="process-request"),
+    path("api/download-csv/", DownloadCSVView.as_view(), name="download-csv")
 ]


### PR DESCRIPTION
Adds method to fetch data for CSV download, fixes #27 
Adds Views and URLs to return downloaded CSV file, fixes #30 

A couple of notes: 
- I know these were two separate issues, but #27 turned out to be a very few lines of code, so I tackled them both in this branch, in part because they are more entangled here than in other request patterns. 
- I got rid of the ProcessRequest method for CSV downloads and am just calling `get_data` directly in the view. My presumption (as the tests show) is that `get_data` will produce a dict that looks like `fixtures/as_data.json`. 
- I've also moved the instantiation of `Aspace` into the `get_data` method, since that's the only place it will be used. There's no reason to create that connection as an attribute on the ProcessRequest class.