### PR TITLE
Adds parse_items method and view

### DIFF
--- a/fixtures/as_data.json
+++ b/fixtures/as_data.json
@@ -7,6 +7,7 @@
     "resource_id": "FA735",
     "containers": "Reel C-1138",
     "preferred_container": "Reel C-1138",
+    "preferred_format": "microfilm",
     "preferred_location": "Rockefeller Archive Center, Blue Level, Vault 106 [Cabinet: 11a, Drawer: 2]",
     "title": "Adler, Mortimer J.",
     "restrictions": "closed",

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -201,45 +201,28 @@ class ProcessRequest(Routine):
                 print(e)
             return 'test'
 
-    def process_readingroom_request(self, object_list):
-        """Processes reading room requests.
+    def parse_items(self, object_list):
+        """Parses items into two lists.
 
         Args:
             object_list (list): A list of AS archival object URIs.
 
         Returns:
-            submitted (list): A list of dicts of submittable objects with corresponding most
+            submittable (list): A list of dicts of submittable objects with corresponding most
                 desirable delivery format.
-            unsubmitted (list): A list of dicts of unsubmittable objects with corresponding
+            unsubmittable (list): A list of dicts of unsubmittable objects with corresponding
                 reason of failure.
         """
+        submittable = []
+        unsubmittable = []
         for item in object_list:
-            try:
-                data = self.get_data(item)
-                print(data)
-            except Exception as e:
-                print(e)
-            return 'test'
-
-    def process_duplication_request(self, object_list):
-        """Processes duplication requests.
-
-        Args:
-            object_list (list): A list of AS archival object URIs.
-
-        Returns:
-            submitted (list): A list of dicts of submittable objects with corresponding most
-                desirable delivery format.
-            unsubmitted (list): A list of dicts of unsubmittable objects with corresponding
-                reason of failure.
-        """
-        for item in object_list:
-            try:
-                self.get_data(item)
-                print('after get_data')
-            except Exception as e:
-                print(e)
-            return 'test'
+            data = self.get_data(item)
+            # TODO: what if there's a URL?
+            if data.get("restriction") or not data.get("container"):
+                unsubmittable.append(data)
+            else:
+                submittable.append(data)
+        return submittable, unsubmittable
 
     def process_csv_request(self, object_list):
         """Processes requests for a CSV download.

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -9,15 +9,16 @@ from rest_framework.views import APIView
 from .routines import DeliverEmail, ProcessRequest
 
 
-class ProcessRequestView(APIView):
-    '''
-    Calls the ProcessRequest class from routines.
-    '''
+class ParseRequestView(APIView):
+    """Parses requests into a submittable and unsubmittable list."""
 
     def post(self, request, format=None):
-        object_list = request.data.get('items')
-        process_list = ProcessRequest().process_readingroom_request(object_list)
-        return Response(process_list, status=200)
+        try:
+            object_list = request.data.get("items")
+            parsed = ProcessRequest().parse_items(object_list)
+            return Response({"items": parsed}, status=200)
+        except Exception as e:
+            return Response({"detail": str(e)}, status=500)
 
 
 class ProcessEmailRequestView(APIView):

--- a/request_broker/urls.py
+++ b/request_broker/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 from process_request.views import (DeliverEmailView, DownloadCSVView,
-                                   ProcessEmailRequestView, ProcessRequestView)
+                                   ParseRequestView, ProcessEmailRequestView)
 from rest_framework import routers
 
 router = routers.DefaultRouter()
@@ -25,7 +25,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include(router.urls)),
     path("api/deliver-request/email", DeliverEmailView.as_view(), name="deliver-email"),
-    path("api/process-request/", ProcessRequestView.as_view(), name="process-request"),
-    path("api/process_request/email", ProcessEmailRequestView.as_view(), name="process-email"),
+    path("api/process-request/parse", ParseRequestView.as_view(), name="parse-request"),
+    path("api/process-request/email", ProcessEmailRequestView.as_view(), name="process-email"),
     path("api/download-csv/", DownloadCSVView.as_view(), name="download-csv")
 ]


### PR DESCRIPTION
This adds a `parse_items` method to the `ProcessRequest` class, as well as a corresponding view and URL config. Although there is only one view here, I believe this fixes #28 as well as fixes #29 (see notes below).

Notes:
- I tweaked the fixture to add a `preferred_format` field. This would be the instance type for whatever instance is selected to be delivered.
- Instead of returning two lists, as was originally specified, this method returns one list, but adds two keys to each item:
  - `submit` - a boolean indicating whether the request should be submitted.
  - `submit_reason` - a human-readable string indicating, if applicable, the reason the request can't be submitted.
- I got rid of the ProcessRequestView and associated tests.