### PR TITLE
Get preferred container ref

### DIFF
--- a/fixtures/object_digital.json
+++ b/fixtures/object_digital.json
@@ -69,7 +69,7 @@
             "jsonmodel_type": "instance",
             "is_representative": false,
             "digital_object": {
-                "ref": "/repositories/2/digital_objects/3367",
+                "ref": "/repositories/2/digital_objects/3368",
                 "_resolved": {
                     "digital_object_id": "238476",
                     "title": "digital object 2",

--- a/fixtures/object_microform.json
+++ b/fixtures/object_microform.json
@@ -38,7 +38,7 @@
             "sub_container": {
                 "jsonmodel_type": "sub_container",
                 "top_container": {
-                    "ref": "/repositories/2/top_containers/191157",
+                    "ref": "/repositories/2/top_containers/191158",
                     "_resolved": {
                         "barcode": "A123456",
                         "indicator": "2",

--- a/fixtures/object_mixed.json
+++ b/fixtures/object_mixed.json
@@ -38,7 +38,7 @@
             "sub_container": {
                 "jsonmodel_type": "sub_container",
                 "top_container": {
-                    "ref": "/repositories/2/top_containers/191157",
+                    "ref": "/repositories/2/top_containers/191158",
                     "_resolved": {
                         "barcode": "A123456",
                         "indicator": "2",

--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -84,7 +84,8 @@ def get_instance_data(instance_list):
 
     Returns:
         tuple: a tuple containing instance type, indicator, location,
-            barcode, and container ref for the instance.
+            container barcode or digital object id, and container/digital object
+            ref for the instance.
     """
     instance_types = []
     containers = []

--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -83,26 +83,30 @@ def get_instance_data(instance_list):
             resolved top containers and digital objects.
 
     Returns:
-        tuple: a tuple containing instance type, indicator, location, and
-            barcode for the instance.
+        tuple: a tuple containing instance type, indicator, location,
+            barcode, and container ref for the instance.
     """
     instance_types = []
     containers = []
     locations = []
     barcodes = []
+    refs = []
     for instance in instance_list:
         if instance["instance_type"] == "digital_object":
             instance_types.append("digital_object")
             containers.append("Digital Object: {}".format(instance.get("digital_object").get("_resolved").get("title")))
             locations.append(get_file_versions(instance.get("digital_object").get("_resolved")))
             barcodes.append(instance.get("digital_object").get("_resolved").get("digital_object_id"))
+            refs.append(instance.get("digital_object").get("ref"))
+            print(instance_types, containers, locations, barcodes, refs)
         else:
             instance_types.append(instance["instance_type"])
             top_container = instance.get("sub_container").get("top_container").get("_resolved")
             containers.append("{} {}".format(top_container.get("type").capitalize(), top_container.get("indicator")))
             locations.append(get_locations(top_container))
             barcodes.append(top_container.get("barcode"))
-    return prepare_values([instance_types, containers, locations, barcodes])
+            refs.append(instance.get("sub_container").get("top_container").get("ref"))
+    return prepare_values([instance_types, containers, locations, barcodes, refs])
 
 
 def get_preferred_format(item_json):
@@ -120,7 +124,7 @@ def get_preferred_format(item_json):
         preferred (tuple): a tuple containing concatenated information of the
             preferred format retrieved by get_instance_data.
     """
-    preferred = None, None, None, None
+    preferred = None, None, None, None, None
     if item_json.get("instances"):
         instances = item_json.get("instances")
         if any("digital_object" in obj for obj in instances):

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -32,7 +32,7 @@ class Processor(object):
             item_json = obj.json()
             item_collection = item_json.get("ancestors")[-1].get("_resolved")
             aggregation = item_json.get("ancestors")[0].get("_resolved").get("display_string") if len(item_json.get("ancestors")) > 1 else None
-            format, container, location, barcode = get_preferred_format(item_json)
+            format, container, location, barcode, ref = get_preferred_format(item_json)
             return {
                 "creator": get_resource_creator(item_collection),
                 "restrictions": "TK",
@@ -48,6 +48,7 @@ class Processor(object):
                 "preferred_container": container,
                 "preferred_location": location,
                 "preferred_barcode": barcode,
+                "preferred_ref": ref,
             }
         else:
             raise Exception(obj.json()["error"])

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -97,37 +97,39 @@ class TestHelpers(TestCase):
 
     def test_get_instance_data(self):
         obj_data = json_from_fixture("digital_object_instance.json")
-        expected_values = ("digital_object", "Digital Object: digital object", "http://google.com", "238475")
+        expected_values = ("digital_object", "Digital Object: digital object", "http://google.com", "238475",
+                           "/repositories/2/digital_objects/3367")
         self.assertEqual(get_instance_data([obj_data]), expected_values)
 
         obj_data = json_from_fixture("mixed_materials_instance.json")
         expected_values = ("mixed materials", "Box 2",
                            "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
-                           "A12345")
+                           "A12345", "/repositories/2/top_containers/191161")
         self.assertEqual(get_instance_data([obj_data]), expected_values)
 
     def test_get_preferred_format(self):
         obj_data = json_from_fixture("object_digital.json")
         expected_data = ("digital_object", "Digital Object: digital object, Digital Object: digital object 2",
-                         "http://google.com, http://google2.com", "238475, 238476")
+                         "http://google.com, http://google2.com", "238475, 238476",
+                         "/repositories/2/digital_objects/3367, /repositories/2/digital_objects/3368")
         self.assertEqual(get_preferred_format(obj_data), expected_data)
 
         obj_data = json_from_fixture("object_microform.json")
         expected_data = ("microform",
                          "Reel 1, Reel 2",
                          "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7], Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  8]",
-                         "A12345, A123456")
+                         "A12345, A123456", "/repositories/2/top_containers/191157, /repositories/2/top_containers/191158")
         self.assertEqual(get_preferred_format(obj_data), expected_data)
 
         obj_data = json_from_fixture("object_mixed.json")
         expected_data = ("mixed materials",
                          "Box 1, Box 2",
                          "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7], Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  8]",
-                         "A12345, A123456")
+                         "A12345, A123456", "/repositories/2/top_containers/191157, /repositories/2/top_containers/191158")
         self.assertEqual(get_preferred_format(obj_data), expected_data)
 
         obj_data = json_from_fixture("object_no_instance.json")
-        expected_data = (None, None, None, None)
+        expected_data = (None, None, None, None, None)
         self.assertEqual(get_preferred_format(obj_data), expected_data)
 
     def test_prepare_values(self):
@@ -199,7 +201,7 @@ class TestRoutines(TestCase):
     def test_get_data(self):
         get_as_data = Processor().get_data("/repositories/2/archival_objects/1134638")
         self.assertTrue(isinstance(get_as_data, dict))
-        self.assertEqual(len(get_as_data), 14)
+        self.assertEqual(len(get_as_data), 15)
 
     @patch("requests.Session.post")
     def test_send_aeon_requests(self, mock_post):


### PR DESCRIPTION
Adds functionality to get refs in `get_preferred_format`. Just grabs the digital object and top container refs from instances and returns them in `Processor`.

Slightly alters and extends tests for `get_instance_data` and `get_preferred_format`.

Nothing radical, just wanted to include this field for Aeon use. Fixes #59 