### PR TITLE
Improve handling of restrictions_text

### DIFF
--- a/fixtures/object_restricted_note_long_open.json
+++ b/fixtures/object_restricted_note_long_open.json
@@ -1,0 +1,13 @@
+{
+  "notes": [{
+    "jsonmodel_type": "note_multipart",
+    "persistent_id": "0322d44b863ca218398f207f55a074cc",
+    "type": "accessrestrict",
+    "subnotes": [{
+      "jsonmodel_type": "note_text",
+      "content": "Open for research. Brittle or damaged items are available at the discretion of RAC. Researchers interested in accessing digital media (floppy disks, CDs, DVDs, etc.) or audiovisual material (audio cassettes, VHS, etc.) in this collection must use an access surrogate. The original items may not be accessed because of preservation concerns. To request an access surrogate be made, or if you are unsure if there is an access surrogate, please contact an archivist.",
+      "publish": true
+    }],
+    "publish": true
+  }]
+}

--- a/fixtures/object_restricted_note_longer_open.json
+++ b/fixtures/object_restricted_note_longer_open.json
@@ -1,0 +1,13 @@
+{
+  "notes": [{
+    "jsonmodel_type": "note_multipart",
+    "persistent_id": "0322d44b863ca218398f207f55a074cc",
+    "type": "accessrestrict",
+    "subnotes": [{
+      "jsonmodel_type": "note_text",
+      "content": "Records more than 20 years old are open for research with select materials restricted as noted. Brittle or damaged items are available at the discretion of RAC. Researchers interested in accessing digital media (floppy disks, CDs, DVDs, etc.) or audiovisual material (audio cassettes, VHS, etc.) in this collection must use an access surrogate. The original items may not be accessed because of preservation concerns. To request an access surrogate be made, or if you are unsure if there is an access surrogate, please contact an archivist.\nThe General Correspondence 1952-1990 has been reformatted to microfilm. User copies are available for research.",
+      "publish": true
+    }],
+    "publish": true
+  }]
+}

--- a/fixtures/object_restricted_note_scholarly_open.json
+++ b/fixtures/object_restricted_note_scholarly_open.json
@@ -1,0 +1,13 @@
+{
+  "notes": [{
+    "jsonmodel_type": "note_multipart",
+    "persistent_id": "0322d44b863ca218398f207f55a074cc",
+    "type": "accessrestrict",
+    "subnotes": [{
+      "jsonmodel_type": "note_text",
+      "content": "Open for scholarly research. Brittle or damaged items are available at the discretion of RAC.",
+      "publish": true
+    }],
+    "publish": true
+  }]
+}

--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -6,8 +6,8 @@ from asnake.utils import get_date_display, get_note_text, text_in_note
 from ordered_set import OrderedSet
 
 CONFIDENCE_RATIO = 97  # Minimum confidence ratio to match against.
-OPEN_TEXT = "Open for research"
-CLOSED_TEXT = "Restricted"
+OPEN_TEXT = ["Open for research", "Open for scholarly research"]
+CLOSED_TEXT = ["Restricted"]
 
 
 def get_container_indicators(item_json):
@@ -204,11 +204,11 @@ def get_rights_status(item_json, client):
                 status = "conditional"
     elif [n for n in item_json.get("notes", []) if n.get("type") == "accessrestrict"]:
         notes = [n for n in item_json["notes"] if n.get("type") == "accessrestrict"]
-        if any([text_in_note(n, CLOSED_TEXT, client, confidence=CONFIDENCE_RATIO) for n in notes]):
+        if any([text_in_note(n, text, client, confidence=CONFIDENCE_RATIO) for text in CLOSED_TEXT for n in notes]):
             status = "closed"
-            if any([text_in_note(n, OPEN_TEXT, client, confidence=CONFIDENCE_RATIO) for n in notes]):
+            if any([text_in_note(n, text, client, confidence=CONFIDENCE_RATIO) for text in OPEN_TEXT for n in notes]):
                 status = "open"
-        elif any([text_in_note(n, OPEN_TEXT, client, confidence=CONFIDENCE_RATIO) for n in notes]):
+        elif any([text_in_note(n, text, client, confidence=CONFIDENCE_RATIO) for text in OPEN_TEXT for n in notes]):
             status = "open"
         else:
             status = "conditional"

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -257,7 +257,7 @@ class AeonRequester(object):
                 "ItemCitation_{}".format(request_prefix): i["uri"],
                 "ItemDate_{}".format(request_prefix): i["dates"],
                 "ItemInfo1_{}".format(request_prefix): i["title"],
-                "ItemInfo2_{}".format(request_prefix): i["restrictions_text"],
+                "ItemInfo2_{}".format(request_prefix): "" if i["restrictions"] == "open" else i["restrictions_text"],
                 "ItemInfo3_{}".format(request_prefix): i["uri"],
                 "ItemInfo4_{}".format(request_prefix): description,
                 "ItemNumber_{}".format(request_prefix): i["preferred_instance"]["barcode"],

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -169,6 +169,8 @@ class TestHelpers(TestCase):
                 ("object_restricted_note.json", "closed"),
                 ("object_restricted_note_conditional.json", "conditional"),
                 ("object_restricted_note_open.json", "open"),
+                ("object_restricted_note_long_open.json", "open"),
+                ("object_restricted_note_longer_open.json", "open"),
                 ("object_restricted_rights_statement.json", "closed"),
                 ("object_restricted_rights_statement_conditional.json", "conditional")]:
             item = json_from_fixture(fixture)

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -171,6 +171,7 @@ class TestHelpers(TestCase):
                 ("object_restricted_note_open.json", "open"),
                 ("object_restricted_note_long_open.json", "open"),
                 ("object_restricted_note_longer_open.json", "open"),
+                ("object_restricted_note_scholarly_open.json", "open"),
                 ("object_restricted_rights_statement.json", "closed"),
                 ("object_restricted_rights_statement_conditional.json", "conditional")]:
             item = json_from_fixture(fixture)


### PR DESCRIPTION
Sends restriction_text only when requested item is not open, since the presence of data in the `ItemInfo2` field results in requests being routed to Awaiting Restrictions Review. Also adds additional coverage for note text parsing.

fixes #95