### PR TITLE
Improve email line breaks

### DIFF
--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -143,7 +143,7 @@ class Mailer(object):
         for obj in object_list:
             for key, label in settings.EXPORT_FIELDS:
                 if obj[key]:
-                    concat_str = "{}: {}\n".format(label, obj[key]) if label else obj[key]
+                    concat_str = "{}: {} \n".format(label, obj[key]) if label else "{} \n".format(obj[key])
                     message += concat_str
             message += "\n"
         return message

--- a/request_broker/settings.py
+++ b/request_broker/settings.py
@@ -152,7 +152,7 @@ DIMES_PREFIX = os.environ.get("DIMES_PREFIX", "https://dimes.rockarch.org")
 EXPORT_FIELDS = [
     ("title", None),
     ("dimes_url", "URL"),
-    ("creators", "Creator/s"),
+    ("creators", "Creator(s)"),
     ("dates", "Dates"),
     ("size", "Size"),
     ("collection_name", "Collection Name"),


### PR DESCRIPTION
Add line break after title
Add space before line breaks and change "Creator(s)" label to prevent unintended link wrapping

fixes #97 