### PR TITLE
Version 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,6 @@ Or, if you want to remove all data
 |POST|/api/process-request/email| |200|Processes data in preparation for sending an email|
 |POST|/api/download-csv/| |200|Downloads a CSV file of items|
 
-### Authorization
-
-This application uses the [Django REST Framework API Key](https://florimondmanca.github.io/djangorestframework-api-key/) library to limit which external applications are able to use its endpoints. All requests must include a `X-Request-Broker-Key` header key with the value of a valid API Key.
-
-API Keys can be be generated in the Django shell:
-```
->>> from rest_framework_api_key.models import APIKey
->>> api_key, key = APIKey.objects.create_key(name="remote-service")
-```
-
-For further details on usage, look at Request Broker's tests or [Django REST Framework API Key documentation](https://florimondmanca.github.io/djangorestframework-api-key/).
-
 ## Requirements
 
 Using this repo requires having [Docker](https://store.docker.com/search?type=edition&offering=community) installed.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
   request-broker-web:
-    image: rockarch/request_broker:0.3
+    image: rockarch/request_broker:0.4
     command: apachectl -D FOREGROUND
     ports:
       - "8001:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - DEBUG=1
       - SECRET_KEY=obop2gifqn6wncaha^dt!w3an-%vkj_&1a@(w-2ci0))^o%#f4
       - DJANGO_ALLOWED_HOSTS=request-broker-web localhost 192.168.1.5
+      - CORS_ALLOWED_ORIGINS=http://localhost:3000 http://rac-vch.ad.rockarchive.org
       - SQL_ENGINE=django.db.backends.postgresql
       - SQL_DATABASE=postgres
       - SQL_USER=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - DEBUG=1
       - SECRET_KEY=obop2gifqn6wncaha^dt!w3an-%vkj_&1a@(w-2ci0))^o%#f4
       - DJANGO_ALLOWED_HOSTS=request-broker-web localhost 192.168.1.5
-      - CORS_ALLOWED_ORIGINS=http://localhost:3000 http://rac-vch.ad.rockarchive.org
+      - CORS_ALLOWED_ORIGINS=http://localhost:3000 http://rac-vch.ad.rockarchive.org:3001
       - SQL_ENGINE=django.db.backends.postgresql
       - SQL_DATABASE=postgres
       - SQL_USER=postgres

--- a/fixtures/as_data.json
+++ b/fixtures/as_data.json
@@ -10,7 +10,7 @@
       "barcode": "A0000000037985",
       "container": "Reel C-1138",
       "format": "microfilm",
-      "location": "Rockefeller Archive Center, Blue Level, Vault 106 [Cabinet: 11a, Drawer: 2]",
+      "location": "106.11a.2",
       "uri": "/top_containers/3314"
     },
     "size": "1 microfilm reel",

--- a/fixtures/as_data.json
+++ b/fixtures/as_data.json
@@ -9,6 +9,7 @@
     "preferred_instance": {
       "barcode": "A0000000037985",
       "container": "Reel C-1138",
+      "subcontainer": "",
       "format": "microfilm",
       "location": "106.11a.2",
       "uri": "/top_containers/3314"

--- a/fixtures/digital_object_instance.json
+++ b/fixtures/digital_object_instance.json
@@ -1,33 +1,21 @@
 {
-    "lock_version": 0,
-    "created_by": "admin",
-    "last_modified_by": "admin",
-    "create_time": "2020-07-28T14:16:54Z",
-    "system_mtime": "2020-07-28T14:16:54Z",
-    "user_mtime": "2020-07-28T14:16:54Z",
     "instance_type": "digital_object",
     "jsonmodel_type": "instance",
     "is_representative": false,
     "digital_object": {
-        "ref": "/repositories/2/digital_objects/3367",
         "_resolved": {
             "digital_object_id": "238475",
             "title": "digital object",
             "file_versions": [
                 {
-                    "lock_version": 0,
                     "file_uri": "http://google.com",
                     "publish": true,
-                    "created_by": "admin",
-                    "last_modified_by": "admin",
-                    "create_time": "2020-07-28T19:44:16Z",
-                    "system_mtime": "2020-07-28T19:44:16Z",
-                    "user_mtime": "2020-07-28T19:44:16Z",
                     "jsonmodel_type": "file_version",
                     "is_representative": false,
                     "identifier": "8475"
                 }
-            ]
+            ],
+            "uri": "/repositories/2/digital_objects/3367"
         }
     }
 }

--- a/fixtures/instances_multiple.json
+++ b/fixtures/instances_multiple.json
@@ -25,7 +25,10 @@
                 "container_locations": [
                     {
                         "_resolved": {
-                            "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+                            "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                            "room": "Vault 106",
+                            "coordinate_1_indicator": "66",
+                            "coordinate_2_indicator": "7"
                         }
                     }
                 ]

--- a/fixtures/instances_plural.json
+++ b/fixtures/instances_plural.json
@@ -27,7 +27,10 @@
                 "container_locations": [
                     {
                         "_resolved": {
-                            "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+                            "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                            "room": "Vault 106",
+                            "coordinate_1_indicator": "66",
+                            "coordinate_2_indicator": "7"
                         }
                     }
                 ]

--- a/fixtures/instances_singular.json
+++ b/fixtures/instances_singular.json
@@ -25,7 +25,10 @@
                 "container_locations": [
                     {
                         "_resolved": {
-                            "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+                            "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                            "room": "Vault 106",
+                            "coordinate_1_indicator": "66",
+                            "coordinate_2_indicator": "7"
                         }
                     }
                 ]

--- a/fixtures/locations.json
+++ b/fixtures/locations.json
@@ -5,7 +5,10 @@
     "container_locations": [
         {
             "_resolved": {
-                "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+                "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                "room": "Vault 106",
+                "coordinate_1_indicator": "66",
+                "coordinate_2_indicator": "7"
             }
         }
     ]

--- a/fixtures/mixed_materials_instance.json
+++ b/fixtures/mixed_materials_instance.json
@@ -1,23 +1,12 @@
 {
-    "lock_version": 0,
-    "created_by": "admin",
-    "last_modified_by": "admin",
-    "create_time": "2020-07-28T14:16:54Z",
-    "system_mtime": "2020-07-28T14:16:54Z",
-    "user_mtime": "2020-07-28T14:16:54Z",
     "instance_type": "mixed materials",
     "jsonmodel_type": "instance",
     "is_representative": false,
     "sub_container": {
-        "lock_version": 0,
-        "created_by": "admin",
-        "last_modified_by": "admin",
-        "create_time": "2020-07-28T14:16:54Z",
-        "system_mtime": "2020-07-28T14:16:54Z",
-        "user_mtime": "2020-07-28T14:16:54Z",
+        "type_2": "folder",
+        "indicator_2": "12",
         "jsonmodel_type": "sub_container",
         "top_container": {
-            "ref": "/repositories/2/top_containers/191161",
             "_resolved": {
                 "type": "box",
                 "indicator": "2",
@@ -31,7 +20,8 @@
                             "coordinate_2_indicator": "7"
                         }
                     }
-                ]
+                ],
+                "uri": "/repositories/2/top_containers/191161"
             }
         }
     }

--- a/fixtures/mixed_materials_instance.json
+++ b/fixtures/mixed_materials_instance.json
@@ -25,7 +25,10 @@
                 "container_locations": [
                     {
                         "_resolved": {
-                            "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+                            "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                            "room": "Vault 106",
+                            "coordinate_1_indicator": "66",
+                            "coordinate_2_indicator": "7"
                         }
                     }
                 ]

--- a/fixtures/object_digital.json
+++ b/fixtures/object_digital.json
@@ -36,7 +36,6 @@
             "jsonmodel_type": "instance",
             "is_representative": false,
             "digital_object": {
-                "ref": "/repositories/2/digital_objects/3367",
                 "_resolved": {
                     "digital_object_id": "238475",
                     "title": "digital object",
@@ -54,7 +53,8 @@
                             "is_representative": false,
                             "identifier": "8475"
                         }
-                    ]
+                    ],
+                    "uri": "/repositories/2/digital_objects/3367"
                 }
             }
         },
@@ -69,7 +69,6 @@
             "jsonmodel_type": "instance",
             "is_representative": false,
             "digital_object": {
-                "ref": "/repositories/2/digital_objects/3368",
                 "_resolved": {
                     "digital_object_id": "238476",
                     "title": "digital object 2",
@@ -87,7 +86,8 @@
                             "is_representative": false,
                             "identifier": "8475"
                         }
-                    ]
+                    ],
+                    "uri": "/repositories/2/digital_objects/3368"
                 }
             }
         },
@@ -110,7 +110,6 @@
                 "user_mtime": "2020-07-28T14:16:54Z",
                 "jsonmodel_type": "sub_container",
                 "top_container": {
-                    "ref": "/repositories/2/top_containers/191161",
                     "_resolved": {
                         "type": "box",
                         "indicator": "2",
@@ -124,7 +123,8 @@
                                     "coordinate_2_indicator": "7"
                                 }
                             }
-                        ]
+                        ],
+                        "uri": "/repositories/2/top_containers/191161"
                     }
                 }
             }

--- a/fixtures/object_digital.json
+++ b/fixtures/object_digital.json
@@ -118,7 +118,10 @@
                         "container_locations": [
                             {
                                 "_resolved": {
-                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                                    "room": "Vault 106",
+                                    "coordinate_1_indicator": "66",
+                                    "coordinate_2_indicator": "7"
                                 }
                             }
                         ]

--- a/fixtures/object_microform.json
+++ b/fixtures/object_microform.json
@@ -25,7 +25,10 @@
                         "container_locations": [
                             {
                                 "_resolved": {
-                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                                    "room": "Vault 106",
+                                    "coordinate_1_indicator": "66",
+                                    "coordinate_2_indicator": "7"
                                 }
                             }
                         ]
@@ -48,7 +51,10 @@
                         "container_locations": [
                             {
                                 "_resolved": {
-                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  8]"
+                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  8]",
+                                    "room": "Vault 106",
+                                    "coordinate_1_indicator": "66",
+                                    "coordinate_2_indicator": "8"
                                 }
                             }
                         ]

--- a/fixtures/object_microform.json
+++ b/fixtures/object_microform.json
@@ -15,7 +15,6 @@
             "sub_container": {
                 "jsonmodel_type": "sub_container",
                 "top_container": {
-                    "ref": "/repositories/2/top_containers/191157",
                     "_resolved": {
                         "barcode": "A12345",
                         "indicator": "1",
@@ -31,7 +30,8 @@
                                     "coordinate_2_indicator": "7"
                                 }
                             }
-                        ]
+                        ],
+                        "uri": "/repositories/2/top_containers/191157"
                     }
                 }
             }
@@ -41,7 +41,6 @@
             "sub_container": {
                 "jsonmodel_type": "sub_container",
                 "top_container": {
-                    "ref": "/repositories/2/top_containers/191158",
                     "_resolved": {
                         "barcode": "A123456",
                         "indicator": "2",
@@ -57,7 +56,8 @@
                                     "coordinate_2_indicator": "8"
                                 }
                             }
-                        ]
+                        ],
+                        "uri": "/repositories/2/top_containers/191158"
                     }
                 }
             }

--- a/fixtures/object_mixed.json
+++ b/fixtures/object_mixed.json
@@ -25,7 +25,10 @@
                         "container_locations": [
                             {
                                 "_resolved": {
-                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                                    "room": "Vault 106",
+                                    "coordinate_1_indicator": "66",
+                                    "coordinate_2_indicator": "7"
                                 }
                             }
                         ]
@@ -48,7 +51,10 @@
                         "container_locations": [
                             {
                                 "_resolved": {
-                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  8]"
+                                    "title": "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  8]",
+                                    "room": "Vault 106",
+                                    "coordinate_1_indicator": "66",
+                                    "coordinate_2_indicator": "8"
                                 }
                             }
                         ]

--- a/fixtures/object_mixed.json
+++ b/fixtures/object_mixed.json
@@ -2,11 +2,6 @@
     "ref_id": "421d180c96c333c196091b797617208c",
     "title": "test1",
     "display_string": "test1",
-    "created_by": "k.martin",
-    "last_modified_by": "admin",
-    "create_time": "2019-12-12T15:52:52Z",
-    "system_mtime": "2020-04-14T15:36:25Z",
-    "user_mtime": "2020-04-14T15:36:25Z",
     "level": "subseries",
     "jsonmodel_type": "archival_object",
     "instances": [
@@ -14,8 +9,9 @@
             "instance_type": "mixed materials",
             "sub_container": {
                 "jsonmodel_type": "sub_container",
+                "type_2": "folder",
+                "indicator_2": "22",
                 "top_container": {
-                    "ref": "/repositories/2/top_containers/191157",
                     "_resolved": {
                         "barcode": "A12345",
                         "indicator": "1",
@@ -31,7 +27,8 @@
                                     "coordinate_2_indicator": "7"
                                 }
                             }
-                        ]
+                        ],
+                        "uri": "/repositories/2/top_containers/191157"
                     }
                 }
             }
@@ -40,8 +37,9 @@
             "instance_type": "mixed materials",
             "sub_container": {
                 "jsonmodel_type": "sub_container",
+                "type_2": "folder",
+                "indicator_2": "11-22",
                 "top_container": {
-                    "ref": "/repositories/2/top_containers/191158",
                     "_resolved": {
                         "barcode": "A123456",
                         "indicator": "2",
@@ -57,7 +55,8 @@
                                     "coordinate_2_indicator": "8"
                                 }
                             }
-                        ]
+                        ],
+                        "uri": "/repositories/2/top_containers/191158"
                     }
                 }
             }

--- a/fixtures/object_restricted_note_long_open.json
+++ b/fixtures/object_restricted_note_long_open.json
@@ -1,0 +1,13 @@
+{
+  "notes": [{
+    "jsonmodel_type": "note_multipart",
+    "persistent_id": "0322d44b863ca218398f207f55a074cc",
+    "type": "accessrestrict",
+    "subnotes": [{
+      "jsonmodel_type": "note_text",
+      "content": "Open for research. Brittle or damaged items are available at the discretion of RAC. Researchers interested in accessing digital media (floppy disks, CDs, DVDs, etc.) or audiovisual material (audio cassettes, VHS, etc.) in this collection must use an access surrogate. The original items may not be accessed because of preservation concerns. To request an access surrogate be made, or if you are unsure if there is an access surrogate, please contact an archivist.",
+      "publish": true
+    }],
+    "publish": true
+  }]
+}

--- a/fixtures/object_restricted_note_longer_open.json
+++ b/fixtures/object_restricted_note_longer_open.json
@@ -1,0 +1,13 @@
+{
+  "notes": [{
+    "jsonmodel_type": "note_multipart",
+    "persistent_id": "0322d44b863ca218398f207f55a074cc",
+    "type": "accessrestrict",
+    "subnotes": [{
+      "jsonmodel_type": "note_text",
+      "content": "Records more than 20 years old are open for research with select materials restricted as noted. Brittle or damaged items are available at the discretion of RAC. Researchers interested in accessing digital media (floppy disks, CDs, DVDs, etc.) or audiovisual material (audio cassettes, VHS, etc.) in this collection must use an access surrogate. The original items may not be accessed because of preservation concerns. To request an access surrogate be made, or if you are unsure if there is an access surrogate, please contact an archivist.\nThe General Correspondence 1952-1990 has been reformatted to microfilm. User copies are available for research.",
+      "publish": true
+    }],
+    "publish": true
+  }]
+}

--- a/fixtures/object_restricted_note_scholarly_open.json
+++ b/fixtures/object_restricted_note_scholarly_open.json
@@ -1,0 +1,13 @@
+{
+  "notes": [{
+    "jsonmodel_type": "note_multipart",
+    "persistent_id": "0322d44b863ca218398f207f55a074cc",
+    "type": "accessrestrict",
+    "subnotes": [{
+      "jsonmodel_type": "note_text",
+      "content": "Open for scholarly research. Brittle or damaged items are available at the discretion of RAC.",
+      "publish": true
+    }],
+    "publish": true
+  }]
+}

--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -59,9 +59,9 @@ def get_locations(top_container_info):
 
     def make_short_location(loc_data):
         return ".".join([
-            loc_data["room"].strip().replace("Vault ", ""),
-            loc_data["coordinate_1_indicator"].strip(),
-            loc_data["coordinate_2_indicator"].strip()])
+            loc_data.get("room", "").strip().replace("Vault ", ""),
+            loc_data.get("coordinate_1_indicator", "").strip(),
+            loc_data.get("coordinate_2_indicator", "").strip()])
 
     locations = None
     if top_container_info.get("container_locations"):

--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -56,9 +56,16 @@ def get_locations(top_container_info):
      Returns:
          string: all locations associated with the top container, separated by a comma.
     """
+
+    def make_short_location(loc_data):
+        return ".".join([
+            loc_data["room"].strip().replace("Vault ", ""),
+            loc_data["coordinate_1_indicator"].strip(),
+            loc_data["coordinate_2_indicator"].strip()])
+
     locations = None
     if top_container_info.get("container_locations"):
-        locations = ",".join([c.get("_resolved").get("title") for c in top_container_info.get("container_locations")])
+        locations = ",".join([make_short_location(c["_resolved"]) for c in top_container_info.get("container_locations")])
     return locations
 
 

--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -6,8 +6,8 @@ from asnake.utils import get_date_display, get_note_text, text_in_note
 from ordered_set import OrderedSet
 
 CONFIDENCE_RATIO = 97  # Minimum confidence ratio to match against.
-OPEN_TEXT = "Open for research"
-CLOSED_TEXT = "Restricted"
+OPEN_TEXT = ["Open for research", "Open for scholarly research"]
+CLOSED_TEXT = ["Restricted"]
 
 
 def get_container_indicators(item_json):
@@ -204,11 +204,11 @@ def get_rights_status(item_json, client):
                 status = "conditional"
     elif [n for n in item_json.get("notes", []) if n.get("type") == "accessrestrict"]:
         notes = [n for n in item_json["notes"] if n.get("type") == "accessrestrict"]
-        if any([text_in_note(n, CLOSED_TEXT, client, confidence=CONFIDENCE_RATIO) for n in notes]):
+        if any([text_in_note(n, text, client, confidence=CONFIDENCE_RATIO) for text in CLOSED_TEXT for n in notes]):
             status = "closed"
-            if any([text_in_note(n, OPEN_TEXT, client, confidence=CONFIDENCE_RATIO) for n in notes]):
+            if any([text_in_note(n, text, client, confidence=CONFIDENCE_RATIO) for text in OPEN_TEXT for n in notes]):
                 status = "open"
-        elif any([text_in_note(n, OPEN_TEXT, client, confidence=CONFIDENCE_RATIO) for n in notes]):
+        elif any([text_in_note(n, text, client, confidence=CONFIDENCE_RATIO) for text in OPEN_TEXT for n in notes]):
             status = "open"
         else:
             status = "conditional"

--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -102,24 +102,29 @@ def get_instance_data(instance_list):
     """
     instance_types = []
     containers = []
+    subcontainers = []
     locations = []
     barcodes = []
     refs = []
     for instance in instance_list:
         if instance["instance_type"] == "digital_object":
             instance_types.append("digital_object")
-            containers.append("Digital Object: {}".format(instance.get("digital_object").get("_resolved").get("title")))
-            locations.append(get_file_versions(instance.get("digital_object").get("_resolved")))
-            barcodes.append(instance.get("digital_object").get("_resolved").get("digital_object_id"))
-            refs.append(instance.get("digital_object").get("ref"))
+            resolved = instance.get("digital_object").get("_resolved")
+            containers.append("Digital Object: {}".format(resolved.get("title")))
+            locations.append(get_file_versions(resolved))
+            barcodes.append(resolved.get("digital_object_id"))
+            refs.append(resolved.get("uri"))
         else:
             instance_types.append(instance["instance_type"])
+            sub_container = instance.get("sub_container")
             top_container = instance.get("sub_container").get("top_container").get("_resolved")
             containers.append("{} {}".format(top_container.get("type").capitalize(), top_container.get("indicator")))
             locations.append(get_locations(top_container))
             barcodes.append(top_container.get("barcode"))
-            refs.append(instance.get("sub_container").get("top_container").get("ref"))
-    return prepare_values([instance_types, containers, locations, barcodes, refs])
+            refs.append(top_container["uri"])
+            if all(["type_2" in sub_container, "indicator_2" in sub_container]):
+                subcontainers.append("{} {}".format(sub_container.get("type_2").capitalize(), sub_container.get("indicator_2")))
+    return prepare_values([instance_types, containers, subcontainers, locations, barcodes, refs])
 
 
 def get_preferred_format(item_json):

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -143,7 +143,7 @@ class Mailer(object):
         for obj in object_list:
             for key, label in settings.EXPORT_FIELDS:
                 if obj[key]:
-                    concat_str = "{}: {}\n".format(label, obj[key]) if label else obj[key]
+                    concat_str = "{}: {} \n".format(label, obj[key]) if label else "{} \n".format(obj[key])
                     message += concat_str
             message += "\n"
         return message

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -167,6 +167,8 @@ class AeonRequester(object):
             "GroupingOption_CallNumber": "FirstValue",
             "GroupingOption_ItemInfo3": "FirstValue",
             "GroupingOption_ItemCitation": "FirstValue",
+            "GroupingOption_ItemNumber": "FirstValue",
+            "GroupingOption_Location": "FirstValue",
             "UserReview": "No",
             "SubmitButton": "Submit Request",
         }

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -144,7 +144,8 @@ class Mailer(object):
             for key, label in settings.EXPORT_FIELDS:
                 if obj[key]:
                     concat_str = "{}: {}\n".format(label, obj[key]) if label else obj[key]
-                    message += "{}\n".format(concat_str)
+                    message += concat_str
+            message += "\n"
         return message
 
 

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -36,7 +36,7 @@ class Processor(object):
             item_json = obj.json()
             item_collection = item_json.get("ancestors")[-1].get("_resolved")
             parent = item_json.get("ancestors")[0].get("_resolved").get("display_string") if len(item_json.get("ancestors")) > 1 else None
-            format, container, location, barcode, container_uri = get_preferred_format(item_json)
+            format, container, subcontainer, location, barcode, container_uri = get_preferred_format(item_json)
             restrictions, restrictions_text = get_rights_info(item_json, aspace.client)
             return {
                 "creators": get_resource_creators(item_collection),
@@ -54,6 +54,7 @@ class Processor(object):
                 "preferred_instance": {
                     "format": format,
                     "container": container,
+                    "subcontainer": subcontainer,
                     "location": location,
                     "barcode": barcode,
                     "uri": container_uri,
@@ -267,6 +268,7 @@ class AeonRequester(object):
                 "ItemSubtitle_{}".format(request_prefix): i["parent"],
                 "ItemTitle_{}".format(request_prefix): i["collection_name"],
                 "ItemVolume_{}".format(request_prefix): i["preferred_instance"]["container"],
+                "ItemIssue_{}".format(request_prefix): i["preferred_instance"]["subcontainer"],
                 "Location_{}".format(request_prefix): i["preferred_instance"]["location"]
             })
         return parsed

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -257,7 +257,7 @@ class AeonRequester(object):
                 "ItemCitation_{}".format(request_prefix): i["uri"],
                 "ItemDate_{}".format(request_prefix): i["dates"],
                 "ItemInfo1_{}".format(request_prefix): i["title"],
-                "ItemInfo2_{}".format(request_prefix): i["restrictions_text"],
+                "ItemInfo2_{}".format(request_prefix): "" if i["restrictions"] == "open" else i["restrictions_text"],
                 "ItemInfo3_{}".format(request_prefix): i["uri"],
                 "ItemInfo4_{}".format(request_prefix): description,
                 "ItemNumber_{}".format(request_prefix): i["preferred_instance"]["barcode"],

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -169,6 +169,8 @@ class TestHelpers(TestCase):
                 ("object_restricted_note.json", "closed"),
                 ("object_restricted_note_conditional.json", "conditional"),
                 ("object_restricted_note_open.json", "open"),
+                ("object_restricted_note_long_open.json", "open"),
+                ("object_restricted_note_longer_open.json", "open"),
                 ("object_restricted_rights_statement.json", "closed"),
                 ("object_restricted_rights_statement_conditional.json", "conditional")]:
             item = json_from_fixture(fixture)

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -216,13 +216,13 @@ class TestRoutines(TestCase):
                 ("conditional", "foobar", True, "This item may be currently unavailable for request. It will be included in request. Reason: foobar")]:
             mock_get_data.return_value["restrictions"] = restrictions
             mock_get_data.return_value["restrictions_text"] = text
-            parsed = Processor().parse_item(mock_get_data.return_value["uri"])
+            parsed = Processor().parse_item(mock_get_data.return_value["uri"], "https://dimes.rockarch.org")
             self.assertEqual(parsed["submit"], submit)
             self.assertEqual(parsed["submit_reason"], reason)
         for format, submit in [
                 ("Digital", False), ("Mixed materials", True), ("microfilm", True)]:
             mock_get_data.return_value["preferred_instance"]["format"] = format
-            parsed = Processor().parse_item(item["uri"])
+            parsed = Processor().parse_item(item["uri"], "https://dimes.rockarch.org")
             self.assertEqual(parsed["submit"], submit)
 
     @patch("process_request.routines.Processor.get_data")
@@ -233,7 +233,7 @@ class TestRoutines(TestCase):
                 ("test@example.com", "Subject"),
                 (["foo@example.com", "bar@example.com"], None)]:
             expected_to = to if isinstance(to, list) else [to]
-            emailed = Mailer().send_message(to, object_list, subject)
+            emailed = Mailer().send_message(to, object_list, subject, "", "https://dimes.rockarch.org")
             self.assertEqual(emailed, "email sent to {}".format(", ".join(expected_to)))
             self.assertTrue(isinstance(mail.outbox[0].to, list))
             self.assertIsNot(mail.outbox[0].subject, None)
@@ -242,7 +242,8 @@ class TestRoutines(TestCase):
 
     @aspace_vcr.use_cassette("aspace_request.json")
     def test_get_data(self):
-        get_as_data = Processor().get_data("/repositories/2/archival_objects/1134638")
+        get_as_data = Processor().get_data("/repositories/2/archival_objects/1134638", "https://dimes.rockarch.org")
+        print(get_as_data)
         self.assertTrue(isinstance(get_as_data, dict))
         self.assertEqual(len(get_as_data), 13)
 
@@ -251,11 +252,11 @@ class TestRoutines(TestCase):
         mock_get_data.return_value = json_from_fixture("as_data.json")
 
         data = {"scheduled_date": date.today().isoformat(), "items": random_list()}
-        delivered = AeonRequester().get_request_data("readingroom", **data)
+        delivered = AeonRequester().get_request_data("readingroom", "https://dimes.rockarch.org", **data)
         self.assertTrue(isinstance(delivered, dict))
 
         data["format"] = "jpeg"
-        delivered = AeonRequester().get_request_data("duplication", **data)
+        delivered = AeonRequester().get_request_data("duplication", "https://dimes.rockarch.org", **data)
         self.assertTrue(isinstance(delivered, dict))
 
         request_type = "foo"

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -171,6 +171,7 @@ class TestHelpers(TestCase):
                 ("object_restricted_note_open.json", "open"),
                 ("object_restricted_note_long_open.json", "open"),
                 ("object_restricted_note_longer_open.json", "open"),
+                ("object_restricted_note_scholarly_open.json", "open"),
                 ("object_restricted_rights_statement.json", "closed"),
                 ("object_restricted_rights_statement_conditional.json", "conditional")]:
             item = json_from_fixture(fixture)

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -100,7 +100,7 @@ class TestHelpers(TestCase):
 
     def test_get_locations(self):
         obj_data = json_from_fixture("locations.json")
-        expected_location = "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]"
+        expected_location = "106.66.7"
         self.assertEqual(get_locations(obj_data), expected_location)
 
     def test_get_instance_data(self):
@@ -111,7 +111,7 @@ class TestHelpers(TestCase):
 
         obj_data = json_from_fixture("mixed_materials_instance.json")
         expected_values = ("mixed materials", "Box 2",
-                           "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7]",
+                           "106.66.7",
                            "A12345", "/repositories/2/top_containers/191161")
         self.assertEqual(get_instance_data([obj_data]), expected_values)
 
@@ -125,14 +125,14 @@ class TestHelpers(TestCase):
         obj_data = json_from_fixture("object_microform.json")
         expected_data = ("microform",
                          "Reel 1, Reel 2",
-                         "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7], Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  8]",
+                         "106.66.7, 106.66.8",
                          "A12345, A123456", "/repositories/2/top_containers/191157, /repositories/2/top_containers/191158")
         self.assertEqual(get_preferred_format(obj_data), expected_data)
 
         obj_data = json_from_fixture("object_mixed.json")
         expected_data = ("mixed materials",
                          "Box 1, Box 2",
-                         "Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  7], Rockefeller Archive Center, Blue Level, Vault 106 [Unit:  66, Shelf:  8]",
+                         "106.66.7, 106.66.8",
                          "A12345, A123456", "/repositories/2/top_containers/191157, /repositories/2/top_containers/191158")
         self.assertEqual(get_preferred_format(obj_data), expected_data)
 

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -105,12 +105,12 @@ class TestHelpers(TestCase):
 
     def test_get_instance_data(self):
         obj_data = json_from_fixture("digital_object_instance.json")
-        expected_values = ("digital_object", "Digital Object: digital object", "http://google.com", "238475",
+        expected_values = ("digital_object", "Digital Object: digital object", None, "http://google.com", "238475",
                            "/repositories/2/digital_objects/3367")
         self.assertEqual(get_instance_data([obj_data]), expected_values)
 
         obj_data = json_from_fixture("mixed_materials_instance.json")
-        expected_values = ("mixed materials", "Box 2",
+        expected_values = ("mixed materials", "Box 2", "Folder 12",
                            "106.66.7",
                            "A12345", "/repositories/2/top_containers/191161")
         self.assertEqual(get_instance_data([obj_data]), expected_values)
@@ -118,13 +118,14 @@ class TestHelpers(TestCase):
     def test_get_preferred_format(self):
         obj_data = json_from_fixture("object_digital.json")
         expected_data = ("digital_object", "Digital Object: digital object, Digital Object: digital object 2",
-                         "http://google.com, http://google2.com", "238475, 238476",
+                         None, "http://google.com, http://google2.com", "238475, 238476",
                          "/repositories/2/digital_objects/3367, /repositories/2/digital_objects/3368")
         self.assertEqual(get_preferred_format(obj_data), expected_data)
 
         obj_data = json_from_fixture("object_microform.json")
         expected_data = ("microform",
                          "Reel 1, Reel 2",
+                         None,
                          "106.66.7, 106.66.8",
                          "A12345, A123456", "/repositories/2/top_containers/191157, /repositories/2/top_containers/191158")
         self.assertEqual(get_preferred_format(obj_data), expected_data)
@@ -132,6 +133,7 @@ class TestHelpers(TestCase):
         obj_data = json_from_fixture("object_mixed.json")
         expected_data = ("mixed materials",
                          "Box 1, Box 2",
+                         "Folder 22, Folder 11-22",
                          "106.66.7, 106.66.8",
                          "A12345, A123456", "/repositories/2/top_containers/191157, /repositories/2/top_containers/191158")
         self.assertEqual(get_preferred_format(obj_data), expected_data)
@@ -243,7 +245,6 @@ class TestRoutines(TestCase):
     @aspace_vcr.use_cassette("aspace_request.json")
     def test_get_data(self):
         get_as_data = Processor().get_data("/repositories/2/archival_objects/1134638", "https://dimes.rockarch.org")
-        print(get_as_data)
         self.assertTrue(isinstance(get_as_data, dict))
         self.assertEqual(len(get_as_data), 13)
 

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -27,7 +27,8 @@ class ParseRequestView(BaseRequestView):
 
     def get_response_data(self, request):
         uri = request.data.get("item")
-        return Processor().parse_item(uri)
+        baseurl = request.META.get("HTTP_ORIGIN", "https://dimes.rockarch.org")
+        return Processor().parse_item(uri, baseurl)
 
 
 class MailerView(BaseRequestView):
@@ -36,9 +37,10 @@ class MailerView(BaseRequestView):
     def get_response_data(self, request):
         object_list = request.data.get("items")
         to_address = request.data.get("email")
-        subject = request.data.get("subject")
+        subject = request.data.get("subject", "")
         message = request.data.get("message")
-        emailed = Mailer().send_message(to_address, object_list, subject, message)
+        baseurl = request.META.get("HTTP_ORIGIN", "https://dimes.rockarch.org")
+        emailed = Mailer().send_message(to_address, object_list, subject, message, baseurl)
         return {"detail": emailed}
 
 
@@ -47,8 +49,9 @@ class DeliverReadingRoomRequestView(BaseRequestView):
 
     def get_response_data(self, request):
         request_data = request.data
+        baseurl = request.META.get("HTTP_ORIGIN", "https://dimes.rockarch.org")
         delivered = AeonRequester().get_request_data(
-            "readingroom", **request_data)
+            "readingroom", baseurl, **request_data)
         return delivered
 
 
@@ -57,8 +60,9 @@ class DeliverDuplicationRequestView(BaseRequestView):
 
     def get_response_data(self, request):
         request_data = request.data
+        baseurl = request.META.get("HTTP_ORIGIN", "https://dimes.rockarch.org")
         delivered = AeonRequester().get_request_data(
-            "duplication", **request_data)
+            "duplication", baseurl, **request_data)
         return delivered
 
 
@@ -87,8 +91,9 @@ class DownloadCSVView(APIView):
         """Streams a large CSV file."""
         try:
             submitted = request.data.get("items")
+            baseurl = request.META.get("HTTP_ORIGIN", "https://dimes.rockarch.org")
             processor = Processor()
-            fetched = [processor.get_data(item) for item in submitted]
+            fetched = [processor.get_data(item, baseurl) for item in submitted]
             response = StreamingHttpResponse(
                 streaming_content=(self.iter_items(fetched, Echo())),
                 content_type="text/csv",

--- a/request_broker/settings.py
+++ b/request_broker/settings.py
@@ -152,7 +152,7 @@ DIMES_PREFIX = os.environ.get("DIMES_PREFIX", "https://dimes.rockarch.org")
 EXPORT_FIELDS = [
     ("title", None),
     ("dimes_url", "URL"),
-    ("creators", "Creator/s"),
+    ("creators", "Creator(s)"),
     ("dates", "Dates"),
     ("size", "Size"),
     ("collection_name", "Collection Name"),

--- a/request_broker/settings.py
+++ b/request_broker/settings.py
@@ -148,7 +148,6 @@ EMAIL_USE_TLS = int(os.environ.get("EMAIL_USE_TLS", default=1))
 EMAIL_USE_SSL = int(os.environ.get("EMAIL_USE_SSL", default=0))
 EMAIL_DEFAULT_FROM = os.environ.get("DEFAULT_FROM_EMAIL", "alerts@example.org")
 
-DIMES_PREFIX = os.environ.get("DIMES_PREFIX", "https://dimes.rockarch.org")
 EXPORT_FIELDS = [
     ("title", None),
     ("dimes_url", "URL"),

--- a/request_broker/settings.py
+++ b/request_broker/settings.py
@@ -131,7 +131,7 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # CORS settings
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOWED_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS").split(" ")
 
 ARCHIVESSPACE = {
     "baseurl": os.environ.get("AS_BASEURL", "http://sandbox.archivesspace.org:8089/"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ clinner==1.12.3
 colorlog==3.2.0
 coverage==5.2.1
 Django==2.2.13
-django-cors-headers==3.4.0
+django-cors-headers==3.6.0
 djangorestframework==3.11.1
 gitdb==4.0.5
 GitPython==3.1.7


### PR DESCRIPTION
- Adds missing grouping fields (ItemNumber and Location)
- Improves email display
- Improves CSV download
- Removes mention of authentication
- Return short location instead of full display text
- Send restriction_text to Aeon only when items may be restricted
- Gets HTTP origin dynamically to provide accurate links in emails
- Add folder numbers to Aeon requests
- Tighten CORS headers