### PR TITLE
Handle objects with no instances

### DIFF
--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -142,7 +142,7 @@ def get_preferred_format(item_json):
         preferred (tuple): a tuple containing concatenated information of the
             preferred format retrieved by get_instance_data.
     """
-    preferred = None, None, None, None, None
+    preferred = None, None, None, None, None, None
     if item_json.get("instances"):
         instances = item_json.get("instances")
         if any("digital_object" in obj for obj in instances):

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -76,9 +76,9 @@ class Processor(object):
         """
         submit = True
         reason = None
-        if not item.get("instances"):
+        if not any(value for value in item["preferred_instance"].values()):
             submit = False
-            reason = "This item is currently unavailable for request. It will not be included in request. Reason: No container information available."
+            reason = "This item is currently unavailable for request. It will not be included in request. Reason: Required information about the physical container of this item is not available."
         elif item["restrictions"] == "closed":
             submit = False
             reason = "This item is currently unavailable for request. It will not be included in request. Reason: {}".format(item.get("restrictions_text"))

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -76,7 +76,10 @@ class Processor(object):
         """
         submit = True
         reason = None
-        if item["restrictions"] == "closed":
+        if not item.get("instances"):
+            submit = False
+            reason = "This item is currently unavailable for request. It will not be included in request. Reason: No container information available."
+        elif item["restrictions"] == "closed":
             submit = False
             reason = "This item is currently unavailable for request. It will not be included in request. Reason: {}".format(item.get("restrictions_text"))
         elif "digital" in item["preferred_instance"]["format"].lower():


### PR DESCRIPTION
Returns an error message for objects with no instances from the `parse` endpoint, fixes #107 
Fixes error message preventing objects with not instances from being emailed, fixes #108 