### PR TITLE
Update dependencies and fix readme build status url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An application that accepts requests with lists of ArchivesSpace URIs from users
 
 The request broker is part of [Project Electron](https://github.com/RockefellerArchiveCenter/project_electron), an initiative to build sustainable, open and user-centered infrastructure for the archival management of digital records at the [Rockefeller Archive Center](http://rockarch.org/).
 
-[![Build Status](https://travis-ci.org/RockefellerArchiveCenter/request_broker.svg?branch=base)](https://travis-ci.org/RockefellerArchiveCenter/request_broker)
+[![Build Status](https://travis-ci.com/RockefellerArchiveCenter/request_broker.svg?branch=base)](https://travis-ci.com/RockefellerArchiveCenter/request_broker)
 
 ## Getting Started
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,11 @@
 ArchivesSnake==0.9.1
-Django==3.2.10
-django-cors-headers==3.10.0
-djangorestframework==3.12.4
+Django==3.2.11
+django-cors-headers==3.10.1
+djangorestframework==3.13.1
 health-check==3.4.1
 inflect==5.3.0
 ordered-set==4.0.2
-psycopg2-binary==2.9.2
-requests==2.26.0
+psycopg2-binary==2.9.3
+requests==2.27.1
 shortuuid==1.0.8
 vcrpy==4.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,26 +8,26 @@ archivessnake==0.9.1
     # via -r requirements.in
 asgiref==3.4.1
     # via django
-attrs==21.2.0
+attrs==21.4.0
     # via archivessnake
 boltons==21.0.0
     # via archivessnake
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.9
+charset-normalizer==2.0.10
     # via requests
 clinner==1.12.3
     # via health-check
 colorlog==3.2.0
     # via clinner
-django==3.2.10
+django==3.2.11
     # via
     #   -r requirements.in
     #   django-cors-headers
     #   djangorestframework
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements.in
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via -r requirements.in
 gitdb==4.0.9
     # via gitpython
@@ -47,10 +47,12 @@ multidict==5.2.0
     # via yarl
 ordered-set==4.0.2
     # via -r requirements.in
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via -r requirements.in
 pytz==2021.3
-    # via django
+    # via
+    #   django
+    #   djangorestframework
 pyyaml==6.0
     # via
     #   archivessnake
@@ -58,7 +60,7 @@ pyyaml==6.0
     #   vcrpy
 rapidfuzz==1.9.1
     # via archivessnake
-requests==2.26.0
+requests==2.27.1
     # via
     #   -r requirements.in
     #   archivessnake
@@ -70,7 +72,7 @@ smmap==5.0.0
     # via gitdb
 sqlparse==0.4.2
     # via django
-structlog==21.4.0
+structlog==21.5.0
     # via archivessnake
 typing-extensions==4.0.1
     # via
@@ -78,7 +80,7 @@ typing-extensions==4.0.1
     #   gitpython
     #   structlog
     #   yarl
-urllib3==1.26.7
+urllib3==1.26.8
     # via requests
 vcrpy==4.1.1
     # via -r requirements.in


### PR DESCRIPTION
- Updates djangorestframework, psycopg2-binary, and requests.
- Updates to Django 3.2.11, but holding off on updating to 4.0.1 because we are using python 3.6.
- Updates django-cors-header to 13.10.1, but holding off on updating to 13.11.x because we are still using python 3.6
- Uses travis.com instead of travis.org in readme build status url