### PR TITLE
Handle cases where item is missing

### DIFF
--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -108,8 +108,10 @@ class Processor(object):
         Returns:
             parsed (dict): A dicts containing parsed item information.
         """
-        data = self.get_data([uri], baseurl)[0]
-        submit, reason = self.is_submittable(data)
+        data = self.get_data([uri], baseurl)
+        if not len(data):
+            return {"uri": uri, "submit": False, "submit_reason": "This item is currently unavailable for request. It will not be included in request. Reason: This item cannot be found."}
+        submit, reason = self.is_submittable(data[0])
         return {"uri": uri, "submit": submit, "submit_reason": reason}
 
 

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -257,6 +257,11 @@ class TestRoutines(TestCase):
         self.assertEqual(parsed["submit"], False)
         self.assertEqual(parsed["submit_reason"], "This item is currently unavailable for request. It will not be included in request. Reason: Required information about the physical container of this item is not available.")
 
+        mock_get_data.return_value = []
+        parsed = Processor().parse_item(item["uri"], "https://dimes.rockarch.org")
+        self.assertEqual(parsed["submit"], False)
+        self.assertEqual(parsed["submit_reason"], "This item is currently unavailable for request. It will not be included in request. Reason: This item cannot be found.")
+
     @patch("process_request.routines.Processor.get_data")
     def test_deliver_email(self, mock_get_data):
         mock_get_data.return_value = [json_from_fixture("as_data.json")]


### PR DESCRIPTION
When a `parse` request is sent for an item which no longer exists, the `submit` and `submit_reason` should be properly set. This handles those cases and sets the `submit` and `submit_reason` values appropriately.