### PR TITLE
Allows configurable mapping from AS data to Aeon Request fields

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max_complexity = 12

--- a/process_request/mappings.py
+++ b/process_request/mappings.py
@@ -1,0 +1,40 @@
+# 'AeonField': 'field_or_callable',
+AEON = {
+    "EADNumber": 'ead_id',
+    "CallNumber": "resource_id",
+    "GroupingField": "get_grouping_field",
+    "ItemAuthor": "get_resource_creators",
+    "ItemCitation": "uri",
+    "ItemDate": "get_dates",
+    "ItemInfo1": "title",
+    "ItemInfo2": "get_rights_text",
+    "ItemInfo3": "uri",
+    "ItemInfo4": "description",
+    "ItemInfo5": "get_restricted_in_container",
+    "ItemNumber": "get_barcode",
+    "ItemSubtitle": "get_parent_title",
+    "ItemTitle": "get_collection_title",
+    "ItemVolume": "get_container",
+    "ItemIssue": "get_subcontainer",
+    "Location": "get_location"
+}
+
+CSV = {
+    "Title": "title",
+    "URL": "get_dimes_url",
+    "Creator(s)": "get_creators",
+    "Dates": "get_dates",
+    "Size": "get_size",
+    "Collection Name": "get_collection_title",
+    "Parent Collection Name": "get_parent_title",
+}
+
+EMAIL = {
+    "Title": "title",
+    "URL": "get_dimes_url",
+    "Creator(s)": "get_creators",
+    "Dates": "get_dates",
+    "Size": "get_size",
+    "Collection Name": "get_collection_title",
+    "Parent Collection Name": "get_parent_title",
+}

--- a/requirements.in
+++ b/requirements.in
@@ -6,5 +6,6 @@ inflect~=5.6
 ordered-set~=4.1
 psycopg2-binary~=2.9
 requests~=2.28
+scalpl~=0.4
 shortuuid~=1.0
 vcrpy~=4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,8 @@ requests==2.28.1
     # via
     #   -r requirements.in
     #   archivessnake
+scalpl==0.4.2
+    # via -r requirements.in
 shortuuid==1.0.9
     # via -r requirements.in
 six==1.16.0


### PR DESCRIPTION
Proof of concept to demonstrate a possible approach to providing configurable mappings from AS to Aeon data. The key piece is these lines, which takes a string representing either a callable in `helpers.py` or a key (using dot notation):

https://github.com/RockefellerArchiveCenter/request_broker/blob/ade866919216e464a60417839e0dd01893956974/process_request/routines.py#L298-L304

If this approach seems promising, I'll need to do additional work to clean up the code, update tests, and possibly do some refactoring of existing helpers to improve performance. I'd also suggest building on the work in #243 and using the Django Admin UI for managing configs, rather than the `mappings.py` file I've provided here.