### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
-FROM python:3.10-buster
+FROM python:3.10
 
 ENV PYTHONUNBUFFERED 1
-RUN apt-get update \
-    && apt-get install -y \
-      postgresql \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /code
 ADD requirements.txt /code/
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Remove unnecessary install of `postgres` and use base Python image instead of Python-buster.