### PR TITLE
Tighten check for digital objects

### DIFF
--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -107,7 +107,7 @@ class Processor(object):
         elif item["restrictions"] == "closed":
             submit = False
             reason = "This item is currently unavailable for request. It will not be included in request. Reason: {}".format(item.get("restrictions_text"))
-        elif "digital" in item["preferred_instance"]["format"].lower():
+        elif item["preferred_instance"]["format"].lower() == "digital_object":
             submit = False
             reason = "This item is already available online. It will not be included in request."
         elif item["restrictions"] == "conditional":

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -267,7 +267,7 @@ class TestRoutines(TestCase):
 
         # Ensure objects with attached digital objects return correct message
         for format, submit in [
-                ("Digital", False), ("Mixed materials", True), ("microfilm", True)]:
+                ("Digital", True), ("digital_object", False), ("Mixed materials", True), ("microfilm", True)]:
             mock_get_data.return_value[0]["preferred_instance"]["format"] = format
             parsed = Processor().parse_item(item["uri"], "https://dimes.rockarch.org")
             self.assertEqual(parsed["submit"], submit)


### PR DESCRIPTION
Checks for occurrences of `digital_object`, not simply `digital` in instance types.

Fixes #284 