### PR TITLE
Allow parsing of multiple URIs in single request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: bionic
 language: python
 python:
   "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: python
 python:
   "3.10"

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -118,6 +118,8 @@ class Processor(object):
         """Parses requested items to determine which are submittable. Adds a
         `submit` and `submit_reason` attribute to each item.
 
+        NOTE: This method is deprecated and will be removed in a future release
+
         Args:
             uri (str): An AS archival object URI.
             baseurl (str): base URL for links to objects in DIMES
@@ -130,6 +132,27 @@ class Processor(object):
             return {"uri": uri, "submit": False, "submit_reason": "This item is currently unavailable for request. It will not be included in request. Reason: This item cannot be found."}
         submit, reason = self.is_submittable(data[0])
         return {"uri": uri, "submit": submit, "submit_reason": reason}
+
+    def parse_items(self, uris, baseurl):
+        """Parses requested items to determine which are submittable. Adds a
+        `submit` and `submit_reason` attribute to each item.
+
+        Args:
+            uris (str): A list of AS archival object URIs.
+            baseurl (str): base URL for links to objects in DIMES
+
+        Returns:
+            parsed (list): A list of dicts containing parsed item information.
+        """
+        parsed = []
+        data = self.get_data(uris, baseurl)
+        for item in data:
+            submit, reason = self.is_submittable(data[0])
+            parsed.append({"uri": item["uri"], "submit": submit, "submit_reason": reason})
+        missing_uris = [m for m in uris if m not in [p["uri"] for p in parsed]]
+        for uri in missing_uris:
+            parsed.append({"uri": uri, "submit": False, "submit_reason": "This item is currently unavailable for request. It will not be included in request. Reason: This item cannot be found."})
+        return parsed
 
 
 class Mailer(object):

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -131,7 +131,7 @@ class Processor(object):
         submit, reason = self.is_submittable(data[0])
         return {"uri": uri, "submit": submit, "submit_reason": reason}
 
-    def parse_items(self, uris, baseurl):
+    def parse_batch(self, uris, baseurl):
         """Parses requested items to determine which are submittable. Adds a
         `submit` and `submit_reason` attribute to each item.
 

--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -115,10 +115,8 @@ class Processor(object):
         return submit, reason
 
     def parse_item(self, uri, baseurl):
-        """Parses requested items to determine which are submittable. Adds a
+        """Parses requested item to determine if it is submittable. Adds a
         `submit` and `submit_reason` attribute to each item.
-
-        NOTE: This method is deprecated and will be removed in a future release
 
         Args:
             uri (str): An AS archival object URI.

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -285,7 +285,7 @@ class TestRoutines(TestCase):
         self.assertEqual(parsed["submit_reason"], "This item is currently unavailable for request. It will not be included in request. Reason: This item cannot be found.")
 
     @patch("process_request.routines.Processor.get_data")
-    def test_parse_items(self, mock_get_data):
+    def test_parse_batch(self, mock_get_data):
         item = json_from_fixture("as_data.json")
         mock_get_data.return_value = [item]
 
@@ -296,7 +296,7 @@ class TestRoutines(TestCase):
                 ("conditional", "foobar", True, "This item may be currently unavailable for request. It will be included in request. Reason: foobar")]:
             mock_get_data.return_value[0]["restrictions"] = restrictions
             mock_get_data.return_value[0]["restrictions_text"] = text
-            parsed = Processor().parse_items([mock_get_data.return_value[0]["uri"]], "https://dimes.rockarch.org")
+            parsed = Processor().parse_batch([mock_get_data.return_value[0]["uri"]], "https://dimes.rockarch.org")
             self.assertIsInstance(parsed, list)
             self.assertEqual(len(parsed), 1)
             item = parsed[0]
@@ -308,18 +308,18 @@ class TestRoutines(TestCase):
         for format, submit in [
                 ("Digital", True), ("digital_object", False), ("Mixed materials", True), ("microfilm", True)]:
             mock_get_data.return_value[0]["preferred_instance"]["format"] = format
-            item = Processor().parse_items([item["uri"]], "https://dimes.rockarch.org")[0]
+            item = Processor().parse_batch([item["uri"]], "https://dimes.rockarch.org")[0]
             self.assertEqual(item["submit"], submit)
 
         # Ensure objects without instances return correct message
         mock_get_data.return_value[0]["preferred_instance"] = {"format": None, "container": None,
                                                                "subcontainer": None, "location": None, "barcode": None, "uri": None}
-        item = Processor().parse_items([item["uri"]], "https://dimes.rockarch.org")[0]
+        item = Processor().parse_batch([item["uri"]], "https://dimes.rockarch.org")[0]
         self.assertEqual(item["submit"], False)
         self.assertEqual(item["submit_reason"], "This item is currently unavailable for request. It will not be included in request. Reason: Required information about the physical container of this item is not available.")
 
         mock_get_data.return_value = []
-        parsed = Processor().parse_items([item["uri"]], "https://dimes.rockarch.org")[0]
+        parsed = Processor().parse_batch([item["uri"]], "https://dimes.rockarch.org")[0]
         self.assertEqual(parsed["submit"], False)
         self.assertEqual(parsed["submit_reason"], "This item is currently unavailable for request. It will not be included in request. Reason: This item cannot be found.")
 
@@ -434,7 +434,7 @@ class TestViews(TestCase):
         self.assert_handles_exceptions(
             mock_parse, "bar", "parse-individual", ParseRequestView)
 
-    @patch("process_request.routines.Processor.parse_items")
+    @patch("process_request.routines.Processor.parse_batch")
     def test_parse_batch_view(self, mock_parse):
         parsed = [{"foo": "bar"}]
         mock_parse.return_value = parsed

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -23,7 +23,7 @@ from .routines import AeonRequester, Mailer, Processor
 from .test_helpers import json_from_fixture, random_list, random_string
 from .views import (DeliverDuplicationRequestView,
                     DeliverReadingRoomRequestView, DownloadCSVView, MailerView,
-                    ParseBatchRequestView, ParseRequestView)
+                    ParseBatchRequestView, ParseItemRequestView)
 
 aspace_vcr = vcr.VCR(
     serializer='json',
@@ -430,9 +430,9 @@ class TestViews(TestCase):
         parsed = {"foo": "bar"}
         mock_parse.return_value = parsed
         self.assert_handles_routine(
-            {"item": random_string()}, "parse-individual", ParseRequestView)
+            {"item": random_string()}, "parse-individual", ParseItemRequestView)
         self.assert_handles_exceptions(
-            mock_parse, "bar", "parse-individual", ParseRequestView)
+            mock_parse, "bar", "parse-individual", ParseItemRequestView)
 
     @patch("process_request.routines.Processor.parse_batch")
     def test_parse_batch_view(self, mock_parse):

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -23,7 +23,7 @@ from .routines import AeonRequester, Mailer, Processor
 from .test_helpers import json_from_fixture, random_list, random_string
 from .views import (DeliverDuplicationRequestView,
                     DeliverReadingRoomRequestView, DownloadCSVView, MailerView,
-                    ParseMultipleRequestView, ParseRequestView)
+                    ParseBatchRequestView, ParseRequestView)
 
 aspace_vcr = vcr.VCR(
     serializer='json',
@@ -430,18 +430,18 @@ class TestViews(TestCase):
         parsed = {"foo": "bar"}
         mock_parse.return_value = parsed
         self.assert_handles_routine(
-            {"item": random_string()}, "parse-request", ParseRequestView)
+            {"item": random_string()}, "parse-individual", ParseRequestView)
         self.assert_handles_exceptions(
-            mock_parse, "bar", "parse-request", ParseRequestView)
+            mock_parse, "bar", "parse-individual", ParseRequestView)
 
     @patch("process_request.routines.Processor.parse_items")
-    def test_parse_multiple_view(self, mock_parse):
+    def test_parse_batch_view(self, mock_parse):
         parsed = [{"foo": "bar"}]
         mock_parse.return_value = parsed
         self.assert_handles_routine(
-            {"item": [random_string()]}, "parse-multiple", ParseMultipleRequestView)
+            {"item": [random_string()]}, "parse-batch", ParseBatchRequestView)
         self.assert_handles_exceptions(
-            mock_parse, "bar", "parse-multiple", ParseMultipleRequestView)
+            mock_parse, "bar", "parse-batch", ParseBatchRequestView)
 
     @patch("process_request.routines.AeonRequester.get_request_data")
     def test_deliver_readingroomrequest_view(self, mock_send):

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -41,7 +41,7 @@ class ParseBatchRequestView(BaseRequestView):
     def get_response_data(self, request):
         uris = request.data.get("items")
         baseurl = request.META.get("HTTP_ORIGIN", settings.DIMES_BASEURL)
-        return Processor().parse_items(uris, baseurl)
+        return Processor().parse_batch(uris, baseurl)
 
 
 class MailerView(BaseRequestView):

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -26,7 +26,7 @@ class BaseRequestView(APIView):
             return Response({"detail": str(e)}, status=500)
 
 
-class ParseRequestView(BaseRequestView):
+class ParseItemRequestView(BaseRequestView):
     """Parses an item to determine whether or not it is submittable."""
 
     def get_response_data(self, request):

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -27,10 +27,7 @@ class BaseRequestView(APIView):
 
 
 class ParseRequestView(BaseRequestView):
-    """Parses an item to determine whether or not it is submittable.
-
-    NOTE: This view is currently deprecated and will be removed in a future release.
-    """
+    """Parses an item to determine whether or not it is submittable."""
 
     def get_response_data(self, request):
         uri = request.data.get("item")
@@ -38,7 +35,7 @@ class ParseRequestView(BaseRequestView):
         return Processor().parse_item(uri, baseurl)
 
 
-class ParseMultipleRequestView(BaseRequestView):
+class ParseBatchRequestView(BaseRequestView):
     """Parses multiple items to determine whether or not they are submittable."""
 
     def get_response_data(self, request):

--- a/process_request/views.py
+++ b/process_request/views.py
@@ -27,12 +27,24 @@ class BaseRequestView(APIView):
 
 
 class ParseRequestView(BaseRequestView):
-    """Parses an item to determine whether or not it is submittable."""
+    """Parses an item to determine whether or not it is submittable.
+
+    NOTE: This view is currently deprecated and will be removed in a future release.
+    """
 
     def get_response_data(self, request):
         uri = request.data.get("item")
         baseurl = request.META.get("HTTP_ORIGIN", settings.DIMES_BASEURL)
         return Processor().parse_item(uri, baseurl)
+
+
+class ParseMultipleRequestView(BaseRequestView):
+    """Parses multiple items to determine whether or not they are submittable."""
+
+    def get_response_data(self, request):
+        uris = request.data.get("items")
+        baseurl = request.META.get("HTTP_ORIGIN", settings.DIMES_BASEURL)
+        return Processor().parse_items(uris, baseurl)
 
 
 class MailerView(BaseRequestView):

--- a/request_broker/urls.py
+++ b/request_broker/urls.py
@@ -19,7 +19,8 @@ from django.urls import path
 from process_request.views import (DeliverDuplicationRequestView,
                                    DeliverReadingRoomRequestView,
                                    DownloadCSVView, LinkResolverView,
-                                   MailerView, ParseRequestView, PingView)
+                                   MailerView, ParseMultipleRequestView,
+                                   ParseRequestView, PingView)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -27,6 +28,7 @@ urlpatterns = [
     path("api/deliver-request/duplication", DeliverDuplicationRequestView.as_view(), name="deliver-duplication"),
     path("api/deliver-request/reading-room", DeliverReadingRoomRequestView.as_view(), name="deliver-readingroom"),
     path("api/process-request/parse", ParseRequestView.as_view(), name="parse-request"),
+    path("api/process-request/parse_multiple", ParseMultipleRequestView.as_view(), name="parse-multiple"),
     path("api/process-request/resolve", LinkResolverView.as_view(), name="resolve-request"),
     path("api/download-csv/", DownloadCSVView.as_view(), name="download-csv"),
     path("api/status/", PingView.as_view(), name="ping")

--- a/request_broker/urls.py
+++ b/request_broker/urls.py
@@ -19,7 +19,7 @@ from django.urls import path
 from process_request.views import (DeliverDuplicationRequestView,
                                    DeliverReadingRoomRequestView,
                                    DownloadCSVView, LinkResolverView,
-                                   MailerView, ParseMultipleRequestView,
+                                   MailerView, ParseBatchRequestView,
                                    ParseRequestView, PingView)
 
 urlpatterns = [
@@ -27,8 +27,8 @@ urlpatterns = [
     path("api/deliver-request/email", MailerView.as_view(), name="deliver-email"),
     path("api/deliver-request/duplication", DeliverDuplicationRequestView.as_view(), name="deliver-duplication"),
     path("api/deliver-request/reading-room", DeliverReadingRoomRequestView.as_view(), name="deliver-readingroom"),
-    path("api/process-request/parse", ParseRequestView.as_view(), name="parse-request"),
-    path("api/process-request/parse_multiple", ParseMultipleRequestView.as_view(), name="parse-multiple"),
+    path("api/process-request/parse", ParseRequestView.as_view(), name="parse-individual"),
+    path("api/process-request/parse_multiple", ParseBatchRequestView.as_view(), name="parse-batch"),
     path("api/process-request/resolve", LinkResolverView.as_view(), name="resolve-request"),
     path("api/download-csv/", DownloadCSVView.as_view(), name="download-csv"),
     path("api/status/", PingView.as_view(), name="ping")

--- a/request_broker/urls.py
+++ b/request_broker/urls.py
@@ -20,14 +20,14 @@ from process_request.views import (DeliverDuplicationRequestView,
                                    DeliverReadingRoomRequestView,
                                    DownloadCSVView, LinkResolverView,
                                    MailerView, ParseBatchRequestView,
-                                   ParseRequestView, PingView)
+                                   ParseItemRequestView, PingView)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/deliver-request/email", MailerView.as_view(), name="deliver-email"),
     path("api/deliver-request/duplication", DeliverDuplicationRequestView.as_view(), name="deliver-duplication"),
     path("api/deliver-request/reading-room", DeliverReadingRoomRequestView.as_view(), name="deliver-readingroom"),
-    path("api/process-request/parse", ParseRequestView.as_view(), name="parse-individual"),
+    path("api/process-request/parse", ParseItemRequestView.as_view(), name="parse-individual"),
     path("api/process-request/parse_multiple", ParseBatchRequestView.as_view(), name="parse-batch"),
     path("api/process-request/resolve", LinkResolverView.as_view(), name="resolve-request"),
     path("api/download-csv/", DownloadCSVView.as_view(), name="download-csv"),


### PR DESCRIPTION
Adds a new endpoint `parse_multiple` to parse multiple URIs at once.

fixes #287 