### PR TITLE
#322: clean container, subcontainer and location for Aeon.

### DIFF
--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -79,9 +79,9 @@ class Processor(object):
                         "size": get_size(item_json["instances"]),
                         "preferred_instance": {
                             "format": format,
-                            "container": container,
-                            "subcontainer": subcontainer,
-                            "location": location,
+                            "container": self.strip_tags(container),
+                            "subcontainer": self.strip_tags(subcontainer),
+                            "location": self.strip_tags(location),
                             "barcode": barcode,
                             "uri": container_uri,
                         }


### PR DESCRIPTION
Resolves #322.

We saw the HTML in `container`; speculatively, I imagine it could also appear in `subcontainer` and `location`.
