### PR TITLE
#325: passthru None on strip_tags()

### DIFF
--- a/process_request/routines.py
+++ b/process_request/routines.py
@@ -21,6 +21,8 @@ class Processor(object):
 
     def strip_tags(self, user_string):
         """Strips XML and HTML tags from a string."""
+        if user_string is None:
+            return None
         try:
             xmldoc = ET.fromstring(f'<xml>{user_string}</xml>')
             textcontent = ''.join(xmldoc.itertext())


### PR DESCRIPTION
Resolves #325, preventing converting `None` to a string.