### PR TITLE
Ensure rights statements are active before evaluating

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   request-broker-db:
     image: postgres:14.4
@@ -14,6 +12,7 @@ services:
     entrypoint: /code/entrypoint.sh
     environment:
       - APPLICATION_PORT=${APPLICATION_PORT:-8000}
+      - SQL_PORT=5432
     volumes:
       - .:/code
     ports:

--- a/fixtures/object_restricted_ancestor.json
+++ b/fixtures/object_restricted_ancestor.json
@@ -43,7 +43,7 @@
           "external_documents": [],
           "acts": [{
             "start_date": "2020-02-07",
-            "end_date": "2020-02-15",
+            "end_date": "2070-02-15",
             "created_by": "admin",
             "last_modified_by": "admin",
             "create_time": "2020-02-10T18:34:17Z",

--- a/fixtures/object_restricted_rights_statement.json
+++ b/fixtures/object_restricted_rights_statement.json
@@ -17,7 +17,7 @@
     "external_documents": [],
     "acts": [{
       "start_date": "2020-02-07",
-      "end_date": "2020-02-15",
+      "end_date": "2070-02-15",
       "created_by": "admin",
       "last_modified_by": "admin",
       "create_time": "2020-02-10T18:34:17Z",

--- a/fixtures/object_restricted_rights_statement_conditional.json
+++ b/fixtures/object_restricted_rights_statement_conditional.json
@@ -17,7 +17,7 @@
     "external_documents": [],
     "acts": [{
       "start_date": "2020-02-07",
-      "end_date": "2020-02-15",
+      "end_date": "2070-02-15",
       "created_by": "admin",
       "last_modified_by": "admin",
       "create_time": "2020-02-10T18:34:17Z",

--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -1,5 +1,6 @@
 import json
 import re
+from datetime import datetime
 
 import inflect
 import shortuuid
@@ -15,6 +16,16 @@ from .models import ReadingRoomCache
 CONFIDENCE_RATIO = 97  # Minimum confidence ratio to match against.
 OPEN_TEXT = ["Open for research", "Open for scholarly research"]
 CLOSED_TEXT = ["Restricted"]
+
+
+def get_active_rights_acts(acts):
+    """Evaluates rights statement act end dates to determine if it is still active."""
+    current_date = datetime.now()
+    for idx, act in reversed(list(enumerate(acts))):
+        statement_end = datetime.strptime(act['end_date'], "%Y-%m-%d")
+        if (current_date > statement_end):
+            acts.pop(idx)
+    return acts
 
 
 def get_container_indicators(item_json):
@@ -260,9 +271,10 @@ def get_rights_status(item_json, client):
     status = None
     if item_json.get("rights_statements"):
         for stmnt in item_json["rights_statements"]:
-            if any([act["restriction"].lower() == "disallow" for act in stmnt.get("acts", [])]):
+            active_acts = get_active_rights_acts(stmnt.get("acts", []))
+            if any([act["restriction"].lower() == "disallow" for act in active_acts]):
                 status = "closed"
-            elif any([act["restriction"].lower() == "conditional" for act in stmnt.get("acts", [])]):
+            elif any([act["restriction"].lower() == "conditional" for act in active_acts]):
                 status = "conditional"
     elif [n for n in item_json.get("notes", []) if n.get("type") == "accessrestrict"]:
         notes = [n for n in item_json["notes"] if n.get("type") == "accessrestrict"]

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -12,12 +12,13 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from rest_framework.test import APIRequestFactory
 
-from .helpers import (get_container_indicators, get_dates, get_file_versions,
-                      get_formatted_resource_id, get_instance_data,
-                      get_locations, get_parent_title, get_preferred_format,
-                      get_resource_creators, get_restricted_in_container,
-                      get_rights_info, get_rights_status, get_rights_text,
-                      get_size, indicator_to_integer, prepare_values)
+from .helpers import (get_active_rights_acts, get_container_indicators,
+                      get_dates, get_file_versions, get_formatted_resource_id,
+                      get_instance_data, get_locations, get_parent_title,
+                      get_preferred_format, get_resource_creators,
+                      get_restricted_in_container, get_rights_info,
+                      get_rights_status, get_rights_text, get_size,
+                      indicator_to_integer, prepare_values)
 from .models import User
 from .routines import AeonRequester, Mailer, Processor
 from .test_helpers import json_from_fixture, random_list, random_string
@@ -54,6 +55,92 @@ class TestHelpers(TestCase):
                              username=settings.ARCHIVESSPACE["username"],
                              password=settings.ARCHIVESSPACE["password"],
                              repository=settings.ARCHIVESSPACE["repo_id"]).client
+
+    def test_get_active_rights_acts(self):
+        """Assert """
+        acts = [
+            {
+                'start_date': '1886-01-01',
+                'end_date': '1967-12-31',
+                'created_by': 'aquarius',
+                'last_modified_by': 'aquarius',
+                'create_time': '2022-06-08T20:55:05Z',
+                'system_mtime': '2022-06-08T20:55:05Z',
+                'user_mtime': '2022-06-08T20:55:05Z',
+                'act_type': 'publish',
+                'restriction':
+                'disallow',
+                'jsonmodel_type':
+                'rights_statement_act',
+                'notes': []
+            },
+            {
+                'start_date': '1886-01-01',
+                'end_date': '2020-12-31',
+                'created_by': 'aquarius',
+                'last_modified_by': 'aquarius',
+                'create_time': '2022-06-08T20:55:05Z',
+                'system_mtime': '2022-06-08T20:55:05Z',
+                'user_mtime': '2022-06-08T20:55:05Z',
+                'act_type': 'publish',
+                'restriction':
+                'disallow',
+                'jsonmodel_type':
+                'rights_statement_act',
+                'notes': []
+            }]
+        output = get_active_rights_acts(acts)
+        self.assertEqual(output, [])
+
+        acts = [
+            {
+                'start_date': '1886-01-01',
+                'end_date': '1967-12-31',
+                'created_by': 'aquarius',
+                'last_modified_by': 'aquarius',
+                'create_time': '2022-06-08T20:55:05Z',
+                'system_mtime': '2022-06-08T20:55:05Z',
+                'user_mtime': '2022-06-08T20:55:05Z',
+                'act_type': 'publish',
+                'restriction':
+                'disallow',
+                'jsonmodel_type':
+                'rights_statement_act',
+                'notes': []
+            },
+            {
+                'start_date': '1886-01-01',
+                'end_date': '2070-12-31',
+                'created_by': 'aquarius',
+                'last_modified_by': 'aquarius',
+                'create_time': '2022-06-08T20:55:05Z',
+                'system_mtime': '2022-06-08T20:55:05Z',
+                'user_mtime': '2022-06-08T20:55:05Z',
+                'act_type': 'publish',
+                'restriction':
+                'disallow',
+                'jsonmodel_type':
+                'rights_statement_act',
+                'notes': []
+            }]
+        expected = [
+            {
+                'start_date': '1886-01-01',
+                'end_date': '2070-12-31',
+                'created_by': 'aquarius',
+                'last_modified_by': 'aquarius',
+                'create_time': '2022-06-08T20:55:05Z',
+                'system_mtime': '2022-06-08T20:55:05Z',
+                'user_mtime': '2022-06-08T20:55:05Z',
+                'act_type': 'publish',
+                'restriction':
+                'disallow',
+                'jsonmodel_type':
+                'rights_statement_act',
+                'notes': []
+            }]
+        output = get_active_rights_acts(acts)
+        self.assertEqual(output, expected)
 
     @patch("asnake.client.web_client.ASnakeClient")
     def test_get_resource_creators(self, mock_client):


### PR DESCRIPTION
- Adds helper to remove all expired rights statement acts before evaluating.
- Updates test fixtures.
- Updates format of docker compose file.

fixes #364 