### PR TITLE
Pass on instances error

### DIFF
--- a/process_request/helpers.py
+++ b/process_request/helpers.py
@@ -408,8 +408,8 @@ def get_size(instances):
                 extent_type = "{} {}".format(instance_type, sub_container_type) if sub_container_type != "box" else sub_container_type
                 extent_number = 1
             extents = append_to_list(extents, extent_type.strip(), extent_number)
-        except Exception as e:
-            raise Exception("Error parsing instances") from e
+        except Exception:
+            pass
     return ", ".join(
         ["{} {}".format(
             e["number"], inflect.engine().plural(e["extent_type"], e["number"])) for e in extents])

--- a/process_request/tests.py
+++ b/process_request/tests.py
@@ -361,13 +361,10 @@ class TestHelpers(TestCase):
         for fixture, size in [
                 ("instances_singular.json", "1 box"),
                 ("instances_multiple.json", "2 boxes"),
-                ("instances_plural.json", "3 folders")]:
+                ("instances_plural.json", "3 folders"),
+                ("instances_error.json", "")]:
             instance = json_from_fixture(fixture)
             self.assertEqual(get_size(instance), size)
-
-        instance = json_from_fixture("instances_error.json")
-        with self.assertRaises(Exception, msg="Error parsing instances"):
-            get_size(instance)
 
     def test_get_title(self):
         for fixture, expected in [


### PR DESCRIPTION
Instances that cannot be parsed for size throw errors in the `get_size` function. Size is a nice-to-have thing, but not necessary.